### PR TITLE
Removed final modifier from JIComRuntimeTransport

### DIFF
--- a/j-interop/src/main/java/org/jinterop/dcom/transport/JIComRuntimeTransport.java
+++ b/j-interop/src/main/java/org/jinterop/dcom/transport/JIComRuntimeTransport.java
@@ -33,7 +33,7 @@ import rpc.core.PresentationSyntax;
  * @exclude @since 1.0
  *
  */
-class JIComRuntimeTransport implements Transport {
+public class JIComRuntimeTransport implements Transport {
 
     public static final String PROTOCOL = "ncacn_ip_tcp";
     private final Properties properties;

--- a/j-interop/src/main/java/org/jinterop/dcom/transport/JIComRuntimeTransport.java
+++ b/j-interop/src/main/java/org/jinterop/dcom/transport/JIComRuntimeTransport.java
@@ -33,7 +33,7 @@ import rpc.core.PresentationSyntax;
  * @exclude @since 1.0
  *
  */
-final class JIComRuntimeTransport implements Transport {
+class JIComRuntimeTransport implements Transport {
 
     public static final String PROTOCOL = "ncacn_ip_tcp";
     private final Properties properties;


### PR DESCRIPTION
For our use case we'd like to be able to extend this class and override the attach method.