### PR TITLE
Allow to customize 'JIComRuntimeTransport' 'socket' and 'endpoint'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow to customize `JIComRuntimeTransport` `socket` and `endpoint`.
+
 ### Changed
 - Update maven plugins dependencies.
 

--- a/j-interop/src/main/java/org/jinterop/dcom/transport/JIComRuntimeTransportFactory.java
+++ b/j-interop/src/main/java/org/jinterop/dcom/transport/JIComRuntimeTransportFactory.java
@@ -19,12 +19,9 @@ package org.jinterop.dcom.transport;
 import java.util.Properties;
 import rpc.ProviderException;
 import rpc.Transport;
+import rpc.TransportFactory;
 
-/**
- * @exclude @since 1.0
- *
- */
-public final class JIComRuntimeTransportFactory extends rpc.TransportFactory {
+public final class JIComRuntimeTransportFactory extends TransportFactory {
 
     private static JIComRuntimeTransportFactory factory = null;
 
@@ -32,8 +29,7 @@ public final class JIComRuntimeTransportFactory extends rpc.TransportFactory {
     }
 
     @Override
-    public Transport createTransport(String address, Properties properties)
-            throws ProviderException {
+    public Transport createTransport(String address, Properties properties) throws ProviderException {
         return new JIComRuntimeTransport(address, properties);
     }
 


### PR DESCRIPTION
Allow to create `JIComRuntimeTransport`  with custom 'socket' and 'endpoint'.

```java
final JIComRuntimeTransport transport =  new JIComRuntimeTransport(properties)
              .withSocketFactory(() -> new Socket())
              .withEndpointFactory((t, p) -> new EndpointXXX());
```
Needed in PR #7 by @AccountToAskQuestions
