### PR TITLE
Apply source forge patch 3 changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Changed
 - Avoid buffer overruns in the NdrBuffer class (Based on [j-interop patch 1](https://sourceforge.net/p/j-interop/patches/1/)).
+- Reset `JIComServer` binding to `null` when unused (Based on [j-interop patch 3](https://sourceforge.net/p/j-interop/patches/3/)).
+- Start `JIComOxidRuntime` ping timer threads on demand (Based on [j-interop patch 3](https://sourceforge.net/p/j-interop/patches/3/)).
 
 ## [3.4.0] - 2022-04-26
 ### Added

--- a/j-interop/src/main/java/org/jinterop/dcom/core/JIComServer.java
+++ b/j-interop/src/main/java/org/jinterop/dcom/core/JIComServer.java
@@ -172,8 +172,8 @@ public final class JIComServer extends Stub {
             //now we choose, otherwise the first one we get.
             while (i < addressBindings.length) {
                 binding = addressBindings[i];
-                if (binding.getTowerId() != 0x07) //this means, even though I asked for TCPIP something else was supplied, noticed this in win2k.
-                {
+                if (binding.getTowerId() != 0x07) { //this means, even though I asked for TCPIP something else was supplied, noticed this in win2k.
+                    binding = null;
                     i++;
                     continue;
                 }
@@ -201,6 +201,7 @@ public final class JIComServer extends Stub {
                     //can only come for the name, saving it incase nothing matches the target address
                     nameBinding = binding;
                 }
+                binding = null;
                 i++;
             }
 


### PR DESCRIPTION
- Reset `JIComServer` binding to `null` when unused.
- Start `JIComOxidRuntime` ping timer threads on demand.